### PR TITLE
change usr-local-etc filename in quick-install

### DIFF
--- a/quick-install.txt
+++ b/quick-install.txt
@@ -22,7 +22,7 @@
 
    #cp usr-local-etc/* /usr/local/etc
 
-   default variables for pgsql_func.conf
+   default variables for pgsql_funcs.conf
    ----
    PGHOST=127.0.0.1
    PGPORT=5432
@@ -30,7 +30,7 @@
    PGDATABASE=postgres
    ----
 
-   default variables for pgpool_func.conf
+   default variables for pgpool_funcs.conf
    ----
    PGPOOLHOST=127.0.0.1
    PGPOOLPORT=9999


### PR DESCRIPTION
correct the filename in quick-install.txt.
when i use pgsql_func.conf  zabbix can't connect with pg.
 
` 10316:20160418:160807.101 error reason for "maj:pgsql.get.pg.slow_query[{$PGSCRIPTDIR},{$PGSCRIPT_CONFDIR},{HOST.HOST},{$ZABBIX_AGENTD_CONF},{$PGSLOWQUERY_TIME_THRESHOLD}]" changed: Received value [/usr/local/bin/pgsql_server_funcs.sh: line 12: /usr/local/etc/pgsql_funcs.conf: No such file or directorypsql: missing "=" after "select" in connection info string] is not suitable for value type [Numeric (unsigned)] and data type [Decimal]`