### PR TITLE
Support for pg96

### DIFF
--- a/pg_monz/usr-local-bin/pgsql_version
+++ b/pg_monz/usr-local-bin/pgsql_version
@@ -1,0 +1,2 @@
+PGVERSION=${PGVERSION:-`psql --version | awk 'NR==1 { print $3 }'`}
+PGMAJORVERSION=`echo "$PGVERSION" | sed 's/^\([0-9]*\.[0-9]*\).*$/\1/'`


### PR DESCRIPTION
With PostgreSQL 9.6, the `waiting` column in `pg_stat_activity` has been replaced with `wait_event` and `wait_event_type`.
https://www.postgresql.org/docs/9.6/static/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW
