### PR TITLE
Fix parameters in proc.num

### DIFF
--- a/pg_monz/template/Template_App_PostgreSQL.xml
+++ b/pg_monz/template/Template_App_PostgreSQL.xml
@@ -637,7 +637,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>proc.num[postgres,,,]</key>
+                    <key>proc.num[postmaster,,,]</key>
                     <delay>300</delay>
                     <history>90</history>
                     <trends>365</trends>
@@ -3237,7 +3237,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template App PostgreSQL:proc.num[postgres,,,].last(0)}=0</expression>
+            <expression>{Template App PostgreSQL:proc.num[postmaster,,,].last(0)}=0</expression>
             <name>PostgreSQL process is not running on {HOST.NAME}</name>
             <url/>
             <status>0</status>

--- a/pg_monz/template/Template_App_PostgreSQL_SR.xml
+++ b/pg_monz/template/Template_App_PostgreSQL_SR.xml
@@ -77,7 +77,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>proc.num[postgres,,,wal receiver]</key>
+                    <key>proc.num[,,,&quot;^postgres:.*wal.*receiver.*process&quot;]</key>
                     <delay>300</delay>
                     <history>90</history>
                     <trends>365</trends>
@@ -120,7 +120,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>proc.num[postgres,,,wal sender]</key>
+                    <key>proc.num[,,,&quot;^postgres:.*wal.*sender.*process&quot;]</key>
                     <delay>300</delay>
                     <history>90</history>
                     <trends>365</trends>


### PR DESCRIPTION
The name `postgres` is a display name in `/proc/[PID]/cmdline` rather than a process name.