### PR TITLE
Add -X to ignore .psqlrc

### DIFF
--- a/pg_monz/usr-local-bin/find_dbname.sh
+++ b/pg_monz/usr-local-bin/find_dbname.sh
@@ -15,7 +15,7 @@ GETDB="select datname from pg_database where datistemplate = 'f';"
 # Load the pgsql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -c "${GETDB}" 2>&1)
+result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -X -c "${GETDB}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$result"
 	exit

--- a/pg_monz/usr-local-bin/find_dbname_table.sh
+++ b/pg_monz/usr-local-bin/find_dbname_table.sh
@@ -41,7 +41,7 @@ GETTABLE="select row_to_json(t) from (select current_database() as \"{#DBNAME}\"
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
 # This low level discovery rules are disabled by deafult.
-dbname_list=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -c "${GETDB}" 2>&1)
+dbname_list=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -X -c "${GETDB}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$dbname_list"
 	exit
@@ -49,7 +49,7 @@ fi
 
 IFS=$'\n'
 for dbname in $dbname_list; do
-	tablename_list=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d ${dbname# } -t -c "${GETTABLE}" 2>&1)
+	tablename_list=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d ${dbname# } -t -X -c "${GETTABLE}" 2>&1)
 	if [ $? -ne 0 ]; then
 		echo "$tablename_list"
 		exit

--- a/pg_monz/usr-local-bin/find_pgpool_backend.sh
+++ b/pg_monz/usr-local-bin/find_pgpool_backend.sh
@@ -9,7 +9,7 @@ POOL_STATUS="show pool_status"
 # Load the pgpool connection option parameters.
 source $PGPOOLSHELL_CONFDIR/pgpool_funcs.conf
 
-config=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${POOL_STATUS}" 2>&1)
+config=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${POOL_STATUS}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$config"
 	exit

--- a/pg_monz/usr-local-bin/find_pgpool_backend_ip.sh
+++ b/pg_monz/usr-local-bin/find_pgpool_backend_ip.sh
@@ -9,7 +9,7 @@ POOL_STATUS="show pool_status"
 # Load the pgpool connection option parameters.
 source $PGPOOLSHELL_CONFDIR/pgpool_funcs.conf
 
-config=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${POOL_STATUS}" 2>&1)
+config=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${POOL_STATUS}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$config"
 	exit
@@ -29,7 +29,7 @@ else
 fi
 
 BACKENDDB="show pool_nodes"
-result=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${BACKENDDB}" 2>&1)
+result=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${BACKENDDB}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$result"
 	exit

--- a/pg_monz/usr-local-bin/find_sr.sh
+++ b/pg_monz/usr-local-bin/find_sr.sh
@@ -7,7 +7,7 @@ GETROW="select count(*) from pg_stat_replication"
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -c "$GETROW" 2>&1)
+result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -X -c "$GETROW" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$result"
 	exit

--- a/pg_monz/usr-local-bin/find_sr_client_ip.sh
+++ b/pg_monz/usr-local-bin/find_sr_client_ip.sh
@@ -7,7 +7,7 @@ GETTABLE="select row_to_json(t) from (select client_addr as \"{#SRCLIENT}\" from
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -c "${GETTABLE}" 2>&1)
+result=$(psql -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -t -X -c "${GETTABLE}" 2>&1)
 if [ $? -ne 0 ]; then
 	echo "$result"
 	exit

--- a/pg_monz/usr-local-bin/pgpool_backend_status.sh
+++ b/pg_monz/usr-local-bin/pgpool_backend_status.sh
@@ -17,7 +17,7 @@ IFS=$'\n'
 
 case "$APP_NAME" in
 	pgpool.nodes)
-		pool_nodes=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${BACKENDDB}" 2>&1)
+		pool_nodes=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${BACKENDDB}" 2>&1)
 
 		if [ $? -ne 0 ]; then
 			echo "$pool_nodes"

--- a/pg_monz/usr-local-bin/pgpool_cache.sh
+++ b/pg_monz/usr-local-bin/pgpool_cache.sh
@@ -15,7 +15,7 @@ source $PGPOOLSHELL_CONFDIR/pgpool_funcs.conf
 
 case "$APP_NAME" in
 	pgpool.cache)
-		pool_cache=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${POOL}" 2>&1)
+		pool_cache=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${POOL}" 2>&1)
 
 		if [ $? -ne 0 ]; then
 			echo "$pool_cache"

--- a/pg_monz/usr-local-bin/pgpool_connections.sh
+++ b/pg_monz/usr-local-bin/pgpool_connections.sh
@@ -15,7 +15,7 @@ source $PGPOOLSHELL_CONFDIR/pgpool_funcs.conf
 
 case "$APP_NAME" in
 	pgpool.connections)
-		pool_connections=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -c "${POOL}" 2>&1)
+		pool_connections=$(psql -A --field-separator=',' -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE -d $PGPOOLDATABASE -t -X -c "${POOL}" 2>&1)
 
 		if [ $? -ne 0 ]; then
 			echo "$pool_connections"

--- a/pg_monz/usr-local-bin/pgpool_simple.sh
+++ b/pg_monz/usr-local-bin/pgpool_simple.sh
@@ -5,7 +5,7 @@ PGSHELL_CONFDIR="$1"
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgpool_funcs.conf
 
-psql -t -A -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE $PGPOOLDATABASE -c "select 1" 2>/dev/null
+psql -t -X -A -h $PGPOOLHOST -p $PGPOOLPORT -U $PGPOOLROLE $PGPOOLDATABASE -c "select 1" 2>/dev/null
 if [ $? -ne 0 ]; then
 	echo 0
 fi

--- a/pg_monz/usr-local-bin/pgsql_db_funcs.sh
+++ b/pg_monz/usr-local-bin/pgsql_db_funcs.sh
@@ -13,7 +13,7 @@ source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
 case "$APP_NAME" in
 	pg.stat_database)
-		sending_data=$(psql -A --field-separator=' ' -t -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
+		sending_data=$(psql -A --field-separator=' ' -t -X -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
 						"select '\"$HOST_NAME\"', 'psql.db_connections[$DBNAME]', $TIMESTAMP_QUERY, (select numbackends from pg_stat_database where datname = '$DBNAME') \
 						union all \
 						select '\"$HOST_NAME\"', 'psql.cachehit_ratio[$DBNAME]', $TIMESTAMP_QUERY, (SELECT round(blks_hit*100/(blks_hit+blks_read), 2) AS cache_hit_ratio FROM pg_stat_database WHERE datname = '$DBNAME' and blks_read > 0 union all select 0.00 AS cache_hit_ratio order by cache_hit_ratio desc limit 1) \

--- a/pg_monz/usr-local-bin/pgsql_primary.sh
+++ b/pg_monz/usr-local-bin/pgsql_primary.sh
@@ -5,5 +5,5 @@ PGSHELL_CONFDIR="$1"
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-result=$(psql -A -t -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select (NOT(pg_is_in_recovery()))::int" 2>&1)
+result=$(psql -A -t -X -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select (NOT(pg_is_in_recovery()))::int" 2>&1)
 echo "$result"

--- a/pg_monz/usr-local-bin/pgsql_simple.sh
+++ b/pg_monz/usr-local-bin/pgsql_simple.sh
@@ -5,7 +5,7 @@ PGSHELL_CONFDIR="$1"
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-psql -t -A -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select 1" 2>/dev/null
+psql -t -X -A -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select 1" 2>/dev/null
 if [ $? -ne 0 ]; then
 	echo 0
 fi

--- a/pg_monz/usr-local-bin/pgsql_sr_server_funcs.sh
+++ b/pg_monz/usr-local-bin/pgsql_sr_server_funcs.sh
@@ -12,7 +12,7 @@ TIMESTAMP_QUERY='extract(epoch from now())::int'
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-PGVERSION=$(psql -A -t -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c 'select * from version()' | cut -d ' ' -f 2 | sed -n 's/^\([0-9]\+\(\.[0-9]\+\)\?\).*$/\1/p')
+PGVERSION=$(psql -A -t -X -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c 'select * from version()' | cut -d ' ' -f 2 | sed -n 's/^\([0-9]\+\(\.[0-9]\+\)\?\).*$/\1/p')
 
 if [ `echo "$PGVERSION >= 10.0" | bc` -eq 1 ]; then
 	WRITE_DIFF_FUNC='pg_wal_lsn_diff(sent_lsn, write_lsn)'
@@ -37,7 +37,7 @@ fi
 #===============================================================================
 case "$APP_NAME" in
 	pg.stat_replication)
-		sending_data=$(psql -A --field-separator=' ' -t -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
+		sending_data=$(psql -A --field-separator=' ' -t -X -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
 						"select * from ( \
 						select '\"$HOST_NAME\"', 'psql.write_diff['||host(client_addr)||']', $TIMESTAMP_QUERY, $WRITE_DIFF_FUNC::text as value from pg_stat_replication \
 						union all \
@@ -51,7 +51,7 @@ case "$APP_NAME" in
 					)
 		;;
 	pg.sr.status)
-		sending_data=$(psql -A --field-separator=' ' -t -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
+		sending_data=$(psql -A --field-separator=' ' -t -X -h $PGHOST -p $PGPORT -U $PGROLE $PGDATABASE -c \
 						"select '\"$HOST_NAME\"', 'psql.block_query', $TIMESTAMP_QUERY, (select CASE count(setting) when 0 then 1 ELSE (select CASE (select pg_is_in_recovery()::int) when 1 then 1 ELSE (select CASE (select count(*) from pg_stat_replication where sync_priority > 0) when 0 then 0 else 1 END) END) END from pg_settings where name ='synchronous_standby_names' and setting !='') \
 						union all \
 						SELECT '\"$HOST_NAME\"','psql.confl_tablespace[' || datname || ']',$TIMESTAMP_QUERY,confl_tablespace from pg_stat_database_conflicts where datname not in ('template1','template0') \

--- a/pg_monz/usr-local-bin/pgsql_standby.sh
+++ b/pg_monz/usr-local-bin/pgsql_standby.sh
@@ -5,5 +5,5 @@ PGSHELL_CONFDIR="$1"
 # Load the psql connection option parameters.
 source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
-result=$(psql -A -t -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select pg_is_in_recovery()::int" 2>&1)
+result=$(psql -A -t -X -h $PGHOST -p $PGPORT -U $PGROLE -d $PGDATABASE -c "select pg_is_in_recovery()::int" 2>&1)
 echo "$result"

--- a/pg_monz/usr-local-bin/pgsql_tbl_funcs.sh
+++ b/pg_monz/usr-local-bin/pgsql_tbl_funcs.sh
@@ -15,7 +15,7 @@ source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
 case "$APP_NAME" in
 	pg.stat_table)
-		sending_data=$(psql -A --field-separator=' ' -t -h $PGHOST -p $PGPORT -U $PGROLE $DBNAME -c \
+		sending_data=$(psql -A --field-separator=' ' -t -X -h $PGHOST -p $PGPORT -U $PGROLE $DBNAME -c \
 						"select '\"$HOST_NAME\"', 'psql.table_analyze_count[$DBNAME,$SCHEMANAME,$TABLENAME]', $TIMESTAMP_QUERY, (select analyze_count from pg_stat_user_tables where schemaname = '$SCHEMANAME' and relname = '$TABLENAME') \
 						union all \
 						select '\"$HOST_NAME\"', 'psql.table_autoanalyze_count[$DBNAME,$SCHEMANAME,$TABLENAME]', $TIMESTAMP_QUERY, (select autoanalyze_count from pg_stat_user_tables where schemaname = '$SCHEMANAME' and relname = '$TABLENAME') \

--- a/pg_monz/usr-local-bin/pgsql_userdb_funcs.sh
+++ b/pg_monz/usr-local-bin/pgsql_userdb_funcs.sh
@@ -13,7 +13,7 @@ source $PGSHELL_CONFDIR/pgsql_funcs.conf
 
 case "$APP_NAME" in
 	pg.size)
-		sending_data=$(psql -A --field-separator=' ' -t -h $PGHOST -p $PGPORT -U $PGROLE $DBNAME -c  \
+		sending_data=$(psql -A --field-separator=' ' -t -X -h $PGHOST -p $PGPORT -U $PGROLE $DBNAME -c  \
 						"select '\"$HOST_NAME\"', 'psql.db_size[$DBNAME]', $TIMESTAMP_QUERY, (select pg_database_size('$DBNAME')) \
 						union all \
 						select '\"$HOST_NAME\"', 'psql.db_garbage_ratio[$DBNAME]', $TIMESTAMP_QUERY, ( \


### PR DESCRIPTION
If the .psqlrc has some verbose settings this will stop some of the scripts working correctly. eg getting the db name list or db table list, etc.

For this -X is added to ignore the .psqlrc config